### PR TITLE
added _site to .gitignore to prevent jekyll built sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ app/_bower_components
 dist
 node_modules
 .tmp
+
+# Ignore Jekyll built _site
+_site


### PR DESCRIPTION
Removing the built _site will help keep our commits readable and meaningful.
