### PR TITLE
Fix/setup documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ app/_bower_components
 dist
 node_modules
 .tmp
+
+# Ignore Jekyll built _site
+_site

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-nclud's sketchbook
+# nclud's sketchbook
+
+## Local Setup 
+
+The `jekyll serve` command must be run from within /path/to/sketchbook/app/.


### PR DESCRIPTION
It took me a minute to realize why running `jekyll serve` from the repo's root gave a 403 Forbidden error in the browser. 

Attempting to run `jekyll serve` from subdirectories would load the HTML, but 404 on all assets. 

This addition to README.md facilitates the local setup.
