### PR TITLE
Add author option to page in front matter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,11 +9,27 @@ name: sketchbook
 description: nclud's sketchbook
 url: http://sketchbook.nclud.com
 
-author:
-  name: nclud
-  email: hello@nclud.com
-  github: nclud
-  twitter: nclud
+authors:
+  default:
+    name: "nclud"
+    image: /img/nclud-logo.png
+    twitter: nclud
+    bio: "A creative design agency focused on unique, stylish and usable experiences across a multitude of verticals, mediums and devices. We work with early stage start-ups, to the Fortune 100, and everyone in between."
+  jesse:
+    name: "Jesse Shawl"
+    image: https://0.gravatar.com/avatar/495991dab64918eb18680073115163aa?d=https%3A%2F%2Fidenticons.github.com%2F0837445cdfc525ca7dcf22cc5b2f8747.png&r=x&s=440
+    twitter: jshawl
+    bio: "Jesse Shawl is a Front End Developer at nclud - whose focus intersects web performance and cutting edge browser interactivity. He's an open source advocate who enjoys building tools for the web with third party API's and mesmerizing CSS animations."
+  jared:
+    name: "Jared Laser"
+    image: foo.jpg
+    twitter: imjared
+    bio: "This is Jared's Bio"
+  max:
+    name: "Maxim Leyzerovich"
+    image: bar.jpg
+    twitter: duqe
+    bio: "this is maxs bio"
 
 # Exclude directories and/or files from the conversion.
 # Grunt moves image files and asset directories.
@@ -25,9 +41,6 @@ exclude: ['img', 'css', 'js', 'fonts',
 include: ['.htaccess']
 
 # Default post path style
-# date  /:categories/:year/:month/:day/:title.html
-# pretty  /:categories/:year/:month/:day/:title/
-# none  /:categories/:title.html
 permalink: /:title/
 
 # Publish posts with future date.
@@ -44,23 +57,6 @@ paginate_path: 'page:num'
 
 # Markdown library
 markdown: maruku
-# Markdown library options
-# maruku:
-  # use_tex:    false
-  # use_divs:   false
-  # png_engine: blahtex
-  # png_dir:    images/latex
-  # png_url:    /images/latex
 
 # Use Pygments to highlight code blocks
 pygments: true
-
-prose:
-  rooturl: "app/_posts"
-  metadata:
-    app/_posts:
-      - name: "layout"
-        field:
-          element: "hidden"
-          value: "post"
-        published: true

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -16,9 +16,14 @@ layout: default
     {{ content }}
 
     <section id="post-footer">
-        <img src="/img/nclud-logo.png" class="post-author-photo">
+    {% if site.authors contains page.author %}
+      {% assign author = site.authors[page.author] %}
+    {% else %}
+      {% assign author = site.authors.default %}
+    {% endif %}
+    <img src="{{author.image}}" class="post-author-photo">
 
-        <a href="https://twitter.com/nclud" target="_blank" class="post-author">nclud</a>
-        <span class="post-author-bio">A creative design agency focused on unique, stylish and usable experiences across a multitude of verticals, mediums and devices. We work with early stage start-ups, to the Fortune 100, and everyone in between.</span>
+    <a href="https://twitter.com/{{author.twitter}}" target="_blank" class="post-author">{{author.name}}</a>
+    <span class="post-author-bio">{{author.bio}}</span>
     </section>
 </article>


### PR DESCRIPTION
If no author is specified in the front matter, like:

```

---
author: jesse

---
```

The author will default to nclud. All of the author bios are managed
in /path/to/sketchbook/_config.yml
